### PR TITLE
Operators for manifest

### DIFF
--- a/manifests/operators/vm_sizing.yml
+++ b/manifests/operators/vm_sizing.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=nessus-manager/vm_type
+  value: ((vm_type))
+
+- type: replace
+  path: /instance_groups/name=nessus-manager/persistent_disk_type
+  value: ((persistent_disk_type))


### PR DESCRIPTION
Adds folder for operators users could take advantage of. Placed a single file for `vm_sizing` but someone could add more for networks, azs, etc.

reliant on https://github.com/18F/cg-nessus-manager-boshrelease/pull/25

