### PR TITLE
update health script checking for outdated plugins

### DIFF
--- a/jobs/nessus-manager/templates/bin/health.sh
+++ b/jobs/nessus-manager/templates/bin/health.sh
@@ -5,7 +5,7 @@ NESSUSD_MESSAGES=/var/vcap/store/nessus-manager/opt/nessus/var/nessus/logs/nessu
 NESSUS_LICENSE=`grep -A1 'nessusd-reloader: started' ${NESSUSD_MESSAGES} | tail -n -1 | grep 'Could not validate the license used on this scanner' | wc -l`
 
 #check plugin age
-PLUGIN_AGE=$(grep 'Nessus is reloading: Plugin auto-update' ${NESSUSD_MESSAGES} | tail -n 1| awk -F '[\[\]]' '{print $2}' | { read datefmt ; echo $(( ($(date +%s) - $(date -d "${datefmt}" +%s)) / 86400 )) ; })
+PLUGIN_AGE=$(grep -e 'Finished plugin update' -e 'Nessus is reloading: Plugin auto-update' ${NESSUSD_MESSAGES} | tail -n 1| awk -F '[\[\]]' '{print $2}' | { read datefmt ; echo $(( ($(date +%s) - $(date -d "${datefmt}" +%s)) / 86400 )) ; })
 
 #emit metrics
 tempfile=`mktemp`


### PR DESCRIPTION
## Changes Proposed

- Update grep patterns used to check Nessus logs for the last time Nessus plugins were updated. The new pattern catches the case where Nessus plugins were updated manually via the web interface or CLI

## Security Considerations

This should make our alerts for Nessus plugins being outdated more accurate, less noisy, and thus more likely to grab our attention when there is a real issue
