### PR TITLE
use fips endpoint for blobstore

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -4,3 +4,4 @@ blobstore:
   provider: s3
   options:
     bucket_name: 18f-boshrelease-blob
+    host: s3-fips.us-gov-west-1.amazonaws.com


### PR DESCRIPTION
## Changes Proposed

- Set the host property to the fips endpoint

## Security Considerations

Instructs bosh to use the fips 140 compliant fips endpoint when interacting with S3.
